### PR TITLE
Separate column for android subversions

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -176,6 +176,10 @@ pre {
   margin-left: 3px;
 }
 
+.level {
+  font-weight: bold;
+}
+
 .table-notes {
   ul {
     margin: 0em;

--- a/index.md
+++ b/index.md
@@ -12,7 +12,9 @@ This is an overview of all Android versions and their corresponding identifiers 
 
 <table class="full-width">
   <tr>
-    <th>Version</th>
+    <th colspan="2">
+      Version
+    </th>
     <th>SDK / API level</th>
     <th><a href="https://developer.android.com/reference/kotlin/android/os/Build.VERSION_CODES">Version code</a></th>
     <th>Codename</th>
@@ -22,10 +24,10 @@ This is an overview of all Android versions and their corresponding identifiers 
     </th>
     <th>Year</th>
   </tr>
+
   <tr>
-    <td>
-      <b><a href="https://developer.android.com/about/versions/13">Android 13</a></b>
-      <sup class="beta">DEV</sup>
+    <td colspan="2">
+      <b><a href="https://developer.android.com/about/versions/13">Android 13</a></b> <sup class="beta">DEV</sup>
     </td>
     <td>Level 33</td>
     <td><code>T</code></td>
@@ -36,29 +38,32 @@ This is an overview of all Android versions and their corresponding identifiers 
     <td rowspan="2"><i>No data</i></td>
     <td rowspan="2"><i>TBA</i></td>
   </tr>
+
   <tr>
     <td rowspan="2">
       <b><a href="https://developer.android.com/about/versions/12">Android 12</a></b>
     </td>
     <td>
-      Level 32
-      <span class="subversion">Android 12L</span>
-      <sup class="beta">BETA</sup>
+      12L <sup class="beta">BETA</sup>
     </td>
+    <td>Level 32</td>
     <td><code>S_V2</code></td>
     <td rowspan="2">
       Snow Cone
       <sup id="fnref:2"><a href="#fn:2" class="footnote">2</a></sup>
     </td>
   </tr>
+  
   <tr>
-    <td>Level 31 <span class="subversion">Android 12</span></td>
+    <td>12</td>
+    <td>Level 31</td>
     <td><code>S</code></td>
     {% include progress-cell.html percentage=7.3 %}
     <td>2021</td>
   </tr>
+
   <tr>
-    <td rowspan="2">
+    <td rowspan="2" colspan="2">
       <b><a href="https://developer.android.com/about/versions/11">Android 11</a></b>
     </td>
     <td>Level 30</td>
@@ -75,8 +80,9 @@ This is an overview of all Android versions and their corresponding identifiers 
       <li><code>targetSdk</code> <a href="https://developer.android.com/distribute/play-policies">must be 30+</a> for new apps and app updates.</li>
     </ul>
   </td></tr>
+
   <tr>
-    <td>
+    <td colspan="2">
       <b><a href="https://developer.android.com/about/versions/10">Android 10</a></b>
     </td>
     <td>Level 29</td>
@@ -88,8 +94,9 @@ This is an overview of all Android versions and their corresponding identifiers 
     {% include progress-cell.html percentage=68.4 %}
     <td>2019</td>
   </tr>
+
   <tr>
-    <td>
+    <td colspan="2">
       <b><a href="https://developer.android.com/about/versions/pie">Android 9</a></b>
     </td>
     <td>Level 28</td>
@@ -98,38 +105,45 @@ This is an overview of all Android versions and their corresponding identifiers 
     {% include progress-cell.html percentage=80.4 %}
     <td>2018</td>
   </tr>
+
   <tr>
     <td rowspan="2">
       <b><a href="https://developer.android.com/about/versions/oreo">Android 8</a></b>
     </td>
-    <td>Level 27 <span class="subversion">Android 8.1</span></td>
+    <td>8.1</td>
+    <td>Level 27</td>
     <td><code>O_MR1</code></td>
     <td rowspan="2">Oreo</td>
     {% include progress-cell.html percentage=86.7 %}
     <td rowspan="2">2017</td>
   </tr>
   <tr>
-    <td>Level 26 <span class="subversion">Android 8.0</span></td>
+    <td>8.0</td>
+    <td>Level 26</td>
     <td><code>O</code></td>
     {% include progress-cell.html percentage=89.4 %}
   </tr>
+
   <tr>
     <td rowspan="2">
       <b><a href="https://developer.android.com/about/versions/nougat">Android 7</a></b>
     </td>
-    <td>Level 25 <span class="subversion">Android 7.1</span></td>
+    <td>7.1</td>
+    <td>Level 25</td>
     <td><code>N_MR1</code></td>
     <td rowspan="2">Nougat</td>
     {% include progress-cell.html percentage=91.1 %}
     <td rowspan="2">2016</td>
   </tr>
   <tr>
-    <td>Level 24 <span class="subversion">Android 7.0</span></td>
+    <td>7.0</td>
+    <td>Level 24</td>
     <td><code>N</code></td>
     {% include progress-cell.html percentage=93.8 %}
   </tr>
+
   <tr>
-    <td>
+    <td colspan="2">
       <b><a href="https://developer.android.com/about/versions/marshmallow">Android 6</a></b>
     </td>
     <td>Level 23</td>
@@ -138,18 +152,21 @@ This is an overview of all Android versions and their corresponding identifiers 
     {% include progress-cell.html percentage=96.6 %}
     <td>2015</td>
   </tr>
+
   <tr>
     <td rowspan="3">
       <b><a href="https://developer.android.com/about/versions/lollipop">Android 5</a></b>
     </td>
-    <td>Level 22 <span class="subversion">Android 5.1</span></td>
+    <td>5.1</td>
+    <td>Level 22</td>
     <td><code>LOLLIPOP_MR1</code></td>
     <td rowspan="2">Lollipop</td>
     {% include progress-cell.html percentage=98.4 %}
     <td>2015</td>
   </tr>
   <tr>
-    <td>Level 21 <span class="subversion">Android 5.0</span></td>
+    <td rowspan="2">5.0</td>
+    <td>Level 21</td>
     <td><code>LOLLIPOP</code>, <code>L</code></td>
     <td rowspan="23"><i>No data</i></td>
     <td rowspan="3">2014</td>
@@ -159,20 +176,19 @@ This is an overview of all Android versions and their corresponding identifiers 
       <li><a href="https://developer.android.com/jetpack/compose">Jetpack Compose</a> requires a <code>minSdk</code> of 21 or higher.</li>
     </ul>
   </td></tr>
+
   <tr>
-    <td rowspan="8"><b>Android 4</b></td>
+    <td rowspan="9"><b>Android 4</b></td>
     <td>
-      Level 20
-      <span class="subversion">Android 4.4W</span> <sup id="fnref:3"><a href="#fn:3" class="footnote">3</a></sup>
+      4.4W <sup id="fnref:3"><a href="#fn:3" class="footnote">3</a></sup>
     </td>
+    <td>Level 20</td>
     <td><code>KITKAT_WATCH</code></td>
     <td rowspan="2">KitKat</td>
   </tr>
   <tr>
-    <td>
-      Level 19
-      <span class="subversion">Android 4.4</span>
-    </td>
+    <td rowspan="2">4.4</td>
+    <td>Level 19</td>
     <td><code>KITKAT</code></td>
     <td rowspan="3">2013</td>
   </tr>
@@ -182,27 +198,32 @@ This is an overview of all Android versions and their corresponding identifiers 
     </ul>
   </td></tr>
   <tr>
-    <td>Level 18 <span class="subversion">Android 4.3</span></td>
+    <td>4.3</td>
+    <td>Level 18</td>
     <td><code>JELLYBEAN_MR2</code></td>
     <td rowspan="3">Jelly Bean</td>
   </tr>
   <tr>
-    <td>Level 17 <span class="subversion">Android 4.2</span></td>
+    <td>4.2</td>
+    <td>Level 17</td>
     <td><code>JELLYBEAN_MR1</code></td>
     <td rowspan="2">2012</td>
   </tr>
   <tr>
-    <td>Level 16 <span class="subversion">Android 4.1</span></td>
+    <td>4.1</td>
+    <td>Level 16</td>
     <td><code>JELLYBEAN</code></td>
   </tr>
   <tr>
-    <td>Level 15 <span class="subversion">Android 4.0.3 – 4.0.4</span></td>
+    <td>4.0.3 – 4.0.4</td>
+    <td>Level 15</td>
     <td><code>ICE_CREAM_SANDWICH_MR1</code></td>
     <td rowspan="2">Ice Cream Sandwich</td>
     <td rowspan="7">2011</td>
   </tr>
   <tr>
-    <td>Level 14 <span class="subversion">Android 4.0.1 – 4.0.2</span></td>
+    <td rowspan="2">4.0.1 – 4.0.2</td>
+    <td>Level 14</td>
     <td><code>ICE_CREAM_SANDWICH</code></td>
   </tr>
   <tr class="table-notes"><td colspan="3">
@@ -210,68 +231,84 @@ This is an overview of all Android versions and their corresponding identifiers 
       <li><a href="https://developer.android.com/jetpack">Jetpack</a>/<a href="https://developer.android.com/jetpack/androidx">AndroidX</a> libraries <a href="https://developer.android.com/topic/libraries/support-library#api-versions">require</a> a <code>minSdk</code> of 14 or higher.</li>
     </ul>
   </td></tr>
+
   <tr>
     <td rowspan="3"><b>Android 3</b></td>
-    <td>Level 13 <span class="subversion">Android 3.2</span></td>
+    <td>3.2</td>
+    <td>Level 13</td>
     <td><code>HONEYCOMB_MR2</code></td>
     <td rowspan="3">Honeycomb</td>
   </tr>
   <tr>
-    <td>Level 12 <span class="subversion">Android 3.1</span></td>
+    <td>3.1</td>
+    <td>Level 12</td>
     <td><code>HONEYCOMB_MR1</code></td>
   </tr>
   <tr>
-    <td>Level 11 <span class="subversion">Android 3.0</span></td>
+    <td>3.0</td>
+    <td>Level 11</td>
     <td><code>HONEYCOMB</code></td>
   </tr>
+
   <tr>
     <td rowspan="6"><b>Android 2</b></td>
-    <td>Level 10 <span class="subversion">Android 2.3.3 – 2.3.7</span></td>
+    <td>2.3.3 – 2.3.7</td>
+    <td>Level 10</td>
     <td><code>GINGERBREAD_MR1</code></td>
     <td rowspan="2">Gingerbread</td>
   </tr>
   <tr>
-    <td>Level 9 <span class="subversion">Android 2.3.0 – 2.3.2</span></td>
+    <td>2.3.0 – 2.3.2</td>
+    <td>Level 9</td>
     <td><code>GINGERBREAD</code></td>
     <td rowspan="3">2010</td>
   </tr>
   <tr>
-    <td>Level 8 <span class="subversion">Android 2.2</span></td>
+    <td>2.2</td>
+    <td>Level 8</td>
     <td><code>FROYO</code></td>
     <td>Froyo</td>
   </tr>
   <tr>
-    <td>Level 7 <span class="subversion">Android 2.1</span></td>
+    <td>2.1</td>
+    <td>Level 7</td>
     <td><code>ECLAIR_MR1</code></td>
     <td rowspan="3">Eclair</td>
   </tr>
   <tr>
-    <td>Level 6 <span class="subversion">Android 2.0.1</span></td>
+    <td>2.0.1</td>
+    <td>Level 6</td>
     <td><code>ECLAIR_0_1</code></td>
     <td rowspan="5">2009</td>
   </tr>
   <tr>
-    <td>Level 5 <span class="subversion">Android 2.0</span></td>
+    <td>2.0</td>
+    <td>Level 5</td>
     <td><code>ECLAIR</code></td>
   </tr>
+
   <tr>
     <td rowspan="4"><b>Android 1</b></td>
-    <td>Level 4 <span class="subversion">Android 1.6</span></td>
+    <td>1.6</td>
+    <td>Level 4</td>
     <td><code>DONUT</code></td>
     <td>Donut</td>
   </tr>
   <tr>
-    <td>Level 3 <span class="subversion">Android 1.5</span></td>
+    <td>1.5</td>
+    <td>Level 3</td>
     <td><code>CUPCAKE</code></td>
     <td>Cupcake</td>
   </tr>
   <tr>
-    <td>Level 2 <span class="subversion">Android 1.1</span></td>
+    <td>1.1</td>
+    <td>Level 2</td>
     <td><code>BASE_1_1</code></td>
     <td>Petit Four</td>
   </tr>
   <tr>
-    <td>Level 1 <span class="subversion">Android 1.0</span></td>
+    <td>1.0</td>
+    <td>Level 1</td>
     <td><code>BASE</code></td>
     <td><i>None</i></td>
     <td>2008</td>

--- a/index.md
+++ b/index.md
@@ -29,7 +29,7 @@ This is an overview of all Android versions and their corresponding identifiers 
     <td colspan="2">
       <b><a href="https://developer.android.com/about/versions/13">Android 13</a></b> <sup class="beta">DEV</sup>
     </td>
-    <td>Level 33</td>
+    <td class="level">Level 33</td>
     <td><code>T</code></td>
     <td>
       Tiramisu
@@ -46,7 +46,7 @@ This is an overview of all Android versions and their corresponding identifiers 
     <td>
       12L <sup class="beta">BETA</sup>
     </td>
-    <td>Level 32</td>
+    <td class="level">Level 32</td>
     <td><code>S_V2</code></td>
     <td rowspan="2">
       Snow Cone
@@ -56,7 +56,7 @@ This is an overview of all Android versions and their corresponding identifiers 
   
   <tr>
     <td>12</td>
-    <td>Level 31</td>
+    <td class="level">Level 31</td>
     <td><code>S</code></td>
     {% include progress-cell.html percentage=7.3 %}
     <td>2021</td>
@@ -66,7 +66,7 @@ This is an overview of all Android versions and their corresponding identifiers 
     <td rowspan="2" colspan="2">
       <b><a href="https://developer.android.com/about/versions/11">Android 11</a></b>
     </td>
-    <td>Level 30</td>
+    <td class="level">Level 30</td>
     <td><code>R</code></td>
     <td>
       Red Velvet Cake
@@ -85,7 +85,7 @@ This is an overview of all Android versions and their corresponding identifiers 
     <td colspan="2">
       <b><a href="https://developer.android.com/about/versions/10">Android 10</a></b>
     </td>
-    <td>Level 29</td>
+    <td class="level">Level 29</td>
     <td><code>Q</code></td>
     <td>
       Quince Tart
@@ -99,7 +99,7 @@ This is an overview of all Android versions and their corresponding identifiers 
     <td colspan="2">
       <b><a href="https://developer.android.com/about/versions/pie">Android 9</a></b>
     </td>
-    <td>Level 28</td>
+    <td class="level">Level 28</td>
     <td><code>P</code></td>
     <td>Pie</td>
     {% include progress-cell.html percentage=80.4 %}
@@ -111,7 +111,7 @@ This is an overview of all Android versions and their corresponding identifiers 
       <b><a href="https://developer.android.com/about/versions/oreo">Android 8</a></b>
     </td>
     <td>8.1</td>
-    <td>Level 27</td>
+    <td class="level">Level 27</td>
     <td><code>O_MR1</code></td>
     <td rowspan="2">Oreo</td>
     {% include progress-cell.html percentage=86.7 %}
@@ -119,7 +119,7 @@ This is an overview of all Android versions and their corresponding identifiers 
   </tr>
   <tr>
     <td>8.0</td>
-    <td>Level 26</td>
+    <td class="level">Level 26</td>
     <td><code>O</code></td>
     {% include progress-cell.html percentage=89.4 %}
   </tr>
@@ -129,7 +129,7 @@ This is an overview of all Android versions and their corresponding identifiers 
       <b><a href="https://developer.android.com/about/versions/nougat">Android 7</a></b>
     </td>
     <td>7.1</td>
-    <td>Level 25</td>
+    <td class="level">Level 25</td>
     <td><code>N_MR1</code></td>
     <td rowspan="2">Nougat</td>
     {% include progress-cell.html percentage=91.1 %}
@@ -137,7 +137,7 @@ This is an overview of all Android versions and their corresponding identifiers 
   </tr>
   <tr>
     <td>7.0</td>
-    <td>Level 24</td>
+    <td class="level">Level 24</td>
     <td><code>N</code></td>
     {% include progress-cell.html percentage=93.8 %}
   </tr>
@@ -146,7 +146,7 @@ This is an overview of all Android versions and their corresponding identifiers 
     <td colspan="2">
       <b><a href="https://developer.android.com/about/versions/marshmallow">Android 6</a></b>
     </td>
-    <td>Level 23</td>
+    <td class="level">Level 23</td>
     <td><code>M</code></td>
     <td>Marshmallow</td>
     {% include progress-cell.html percentage=96.6 %}
@@ -158,7 +158,7 @@ This is an overview of all Android versions and their corresponding identifiers 
       <b><a href="https://developer.android.com/about/versions/lollipop">Android 5</a></b>
     </td>
     <td>5.1</td>
-    <td>Level 22</td>
+    <td class="level">Level 22</td>
     <td><code>LOLLIPOP_MR1</code></td>
     <td rowspan="2">Lollipop</td>
     {% include progress-cell.html percentage=98.4 %}
@@ -166,7 +166,7 @@ This is an overview of all Android versions and their corresponding identifiers 
   </tr>
   <tr>
     <td rowspan="2">5.0</td>
-    <td>Level 21</td>
+    <td class="level">Level 21</td>
     <td><code>LOLLIPOP</code>, <code>L</code></td>
     <td rowspan="24"><i>No data</i></td>
     <td rowspan="3">2014</td>
@@ -182,13 +182,13 @@ This is an overview of all Android versions and their corresponding identifiers 
     <td>
       4.4W <sup id="fnref:3"><a href="#fn:3" class="footnote">3</a></sup>
     </td>
-    <td>Level 20</td>
+    <td class="level">Level 20</td>
     <td><code>KITKAT_WATCH</code></td>
     <td rowspan="2">KitKat</td>
   </tr>
   <tr>
     <td rowspan="2">4.4</td>
-    <td>Level 19</td>
+    <td class="level">Level 19</td>
     <td><code>KITKAT</code></td>
     <td rowspan="3">2013</td>
   </tr>
@@ -199,31 +199,31 @@ This is an overview of all Android versions and their corresponding identifiers 
   </td></tr>
   <tr>
     <td>4.3</td>
-    <td>Level 18</td>
+    <td class="level">Level 18</td>
     <td><code>JELLYBEAN_MR2</code></td>
     <td rowspan="3">Jelly Bean</td>
   </tr>
   <tr>
     <td>4.2</td>
-    <td>Level 17</td>
+    <td class="level">Level 17</td>
     <td><code>JELLYBEAN_MR1</code></td>
     <td rowspan="2">2012</td>
   </tr>
   <tr>
     <td>4.1</td>
-    <td>Level 16</td>
+    <td class="level">Level 16</td>
     <td><code>JELLYBEAN</code></td>
   </tr>
   <tr>
     <td>4.0.3 – 4.0.4</td>
-    <td>Level 15</td>
+    <td class="level">Level 15</td>
     <td><code>ICE_CREAM_SANDWICH_MR1</code></td>
     <td rowspan="2">Ice Cream Sandwich</td>
     <td rowspan="7">2011</td>
   </tr>
   <tr>
     <td rowspan="2">4.0.1 – 4.0.2</td>
-    <td>Level 14</td>
+    <td class="level">Level 14</td>
     <td><code>ICE_CREAM_SANDWICH</code></td>
   </tr>
   <tr class="table-notes"><td colspan="3">
@@ -235,80 +235,80 @@ This is an overview of all Android versions and their corresponding identifiers 
   <tr>
     <td rowspan="3"><b>Android 3</b></td>
     <td>3.2</td>
-    <td>Level 13</td>
+    <td class="level">Level 13</td>
     <td><code>HONEYCOMB_MR2</code></td>
     <td rowspan="3">Honeycomb</td>
   </tr>
   <tr>
     <td>3.1</td>
-    <td>Level 12</td>
+    <td class="level">Level 12</td>
     <td><code>HONEYCOMB_MR1</code></td>
   </tr>
   <tr>
     <td>3.0</td>
-    <td>Level 11</td>
+    <td class="level">Level 11</td>
     <td><code>HONEYCOMB</code></td>
   </tr>
 
   <tr>
     <td rowspan="6"><b>Android 2</b></td>
     <td>2.3.3 – 2.3.7</td>
-    <td>Level 10</td>
+    <td class="level">Level 10</td>
     <td><code>GINGERBREAD_MR1</code></td>
     <td rowspan="2">Gingerbread</td>
   </tr>
   <tr>
     <td>2.3.0 – 2.3.2</td>
-    <td>Level 9</td>
+    <td class="level">Level 9</td>
     <td><code>GINGERBREAD</code></td>
     <td rowspan="3">2010</td>
   </tr>
   <tr>
     <td>2.2</td>
-    <td>Level 8</td>
+    <td class="level">Level 8</td>
     <td><code>FROYO</code></td>
     <td>Froyo</td>
   </tr>
   <tr>
     <td>2.1</td>
-    <td>Level 7</td>
+    <td class="level">Level 7</td>
     <td><code>ECLAIR_MR1</code></td>
     <td rowspan="3">Eclair</td>
   </tr>
   <tr>
     <td>2.0.1</td>
-    <td>Level 6</td>
+    <td class="level">Level 6</td>
     <td><code>ECLAIR_0_1</code></td>
     <td rowspan="5">2009</td>
   </tr>
   <tr>
     <td>2.0</td>
-    <td>Level 5</td>
+    <td class="level">Level 5</td>
     <td><code>ECLAIR</code></td>
   </tr>
 
   <tr>
     <td rowspan="4"><b>Android 1</b></td>
     <td>1.6</td>
-    <td>Level 4</td>
+    <td class="level">Level 4</td>
     <td><code>DONUT</code></td>
     <td>Donut</td>
   </tr>
   <tr>
     <td>1.5</td>
-    <td>Level 3</td>
+    <td class="level">Level 3</td>
     <td><code>CUPCAKE</code></td>
     <td>Cupcake</td>
   </tr>
   <tr>
     <td>1.1</td>
-    <td>Level 2</td>
+    <td class="level">Level 2</td>
     <td><code>BASE_1_1</code></td>
     <td>Petit Four</td>
   </tr>
   <tr>
     <td>1.0</td>
-    <td>Level 1</td>
+    <td class="level">Level 1</td>
     <td><code>BASE</code></td>
     <td><i>None</i></td>
     <td>2008</td>


### PR DESCRIPTION
Experimenting with moving the Android subversions (e.g. 12, 12L) into a separate subcolumn of the "Versions" column.

![image](https://user-images.githubusercontent.com/4406614/157561609-d1eadda2-aa61-4023-971b-32d35e861cee.png)
