### PR TITLE
add print media css rules

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -279,3 +279,29 @@ pre {
   opacity: 0.65;
   font-style: italic;
 }
+
+@media print {
+  #site-title,
+  #intro,
+  #compact-toc {
+    display: none;
+  }
+
+  #page-content,
+  table {
+    margin: 0;
+  }
+
+  .table-responsive {
+    page-break-inside: avoid;
+  }
+
+  #main-table {
+    page-break-after: always;
+  }
+
+  a {
+    color: $body-color;
+    text-decoration: none !important;
+  }
+}

--- a/index.md
+++ b/index.md
@@ -3,14 +3,16 @@ layout: default
 ---
 {::options parse_block_html="true" /}
 
+<p id="intro">
 This is an overview of all Android versions and their corresponding identifiers for Android developers. Anyone is welcome to open [an issue or pull request](https://github.com/ebelinski/apilevels). Happy developing!
+</p>
 
 <div id="compact-toc">
 * TOC
 {:toc}
 </div>
 
-<div class="table-responsive">
+<div id="main-table" class="table-responsive">
 <table class="full-width">
   <tr>
     <th>Version</th>


### PR DESCRIPTION
The PR adds some css rules to fit the entire version table on a single page.

See pdf for an example [API Levels Print test.pdf](https://github.com/ebelinski/apilevels/files/11965341/API.Levels.Print.test.pdf)

The entire table might eventually not fit on a single page after a few more rows are added so at that point it might make sense to page break intentionally or reduce the padding of the table to fit more on one page.

Let me know if you want me to add a different padding to the table to the PR.
