### PR TITLE
Update liquid gem to resolve issues with Ruby >= 3.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    liquid (4.0.3)
+    liquid (4.0.4)
     listen (3.4.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)


### PR DESCRIPTION
I realize the official supported version of Ruby is 3.0 for this project, but this tiny patch version bump allows it to work for users on newer versions rather than needing to install a whole separate ruby environment.