### PR TITLE
Update stats.

### DIFF
--- a/index.md
+++ b/index.md
@@ -57,7 +57,7 @@ This is an overview of all Android versions and their corresponding identifiers 
       Tiramisu
       <sup id="fnref:2"><a href="#fn:2" class="footnote">2</a></sup>
     </td>
-    {% include progress-cell.html rowspan=2 percentage=36.5 %}
+    {% include progress-cell.html rowspan=2 percentage=38.8 %}
     <td rowspan="3">2022</td>
   </tr>
   <tr class="table-notes">
@@ -80,7 +80,7 @@ This is an overview of all Android versions and their corresponding identifiers 
       Snow Cone
       <sup id="fnref:2"><a href="#fn:2" class="footnote">2</a></sup>
     </td>
-    {% include progress-cell.html rowspan=2 percentage=54.7 %}
+    {% include progress-cell.html rowspan=2 percentage=56.8 %}
   </tr>
   <tr>
     <td>Level 31 <span class="subversion">Android 12</span></td>
@@ -97,7 +97,7 @@ This is an overview of all Android versions and their corresponding identifiers 
       Red Velvet Cake
       <sup id="fnref:2"><a href="#fn:2" class="footnote">2</a></sup>
     </td>
-    {% include progress-cell.html rowspan=1 percentage=72.5 %}
+    {% include progress-cell.html rowspan=1 percentage=74.2 %}
     <td>2020</td>
   </tr>
   <tr>
@@ -110,7 +110,7 @@ This is an overview of all Android versions and their corresponding identifiers 
       Quince Tart
       <sup id="fnref:2"><a href="#fn:2" class="footnote">2</a></sup>
     </td>
-    {% include progress-cell.html rowspan=1 percentage=81.9 %}
+    {% include progress-cell.html rowspan=1 percentage=83.3 %}
     <td>2019</td>
   </tr>
   <tr>
@@ -120,7 +120,7 @@ This is an overview of all Android versions and their corresponding identifiers 
     <td>Level 28</td>
     <td><code>P</code></td>
     <td>Pie</td>
-    {% include progress-cell.html rowspan=1 percentage=88.5 %}
+    {% include progress-cell.html rowspan=1 percentage=89.7 %}
     <td>2018</td>
   </tr>
   <tr>
@@ -130,13 +130,13 @@ This is an overview of all Android versions and their corresponding identifiers 
     <td>Level 27 <span class="subversion">Android 8.1</span></td>
     <td><code>O_MR1</code></td>
     <td rowspan="2">Oreo</td>
-    {% include progress-cell.html rowspan=1 percentage=90.8 %}
+    {% include progress-cell.html rowspan=1 percentage=91.9 %}
     <td rowspan="2">2017</td>
   </tr>
   <tr>
     <td>Level 26 <span class="subversion">Android 8.0</span></td>
     <td><code>O</code></td>
-    {% include progress-cell.html rowspan=1 percentage=94.0 %}
+    {% include progress-cell.html rowspan=1 percentage=94.9 %}
   </tr>
   <tr>
     <td rowspan="2">
@@ -145,13 +145,13 @@ This is an overview of all Android versions and their corresponding identifiers 
     <td>Level 25 <span class="subversion">Android 7.1</span></td>
     <td><code>N_MR1</code></td>
     <td rowspan="2">Nougat</td>
-    {% include progress-cell.html rowspan=1 percentage=94.5 %}
+    {% include progress-cell.html rowspan=1 percentage=95.3 %}
     <td rowspan="2">2016</td>
   </tr>
   <tr>
     <td>Level 24 <span class="subversion">Android 7.0</span></td>
     <td><code>N</code></td>
-    {% include progress-cell.html rowspan=1 percentage=96.1 %}
+    {% include progress-cell.html rowspan=1 percentage=96.8 %}
   </tr>
   <tr>
     <td>
@@ -160,7 +160,7 @@ This is an overview of all Android versions and their corresponding identifiers 
     <td>Level 23</td>
     <td><code>M</code></td>
     <td>Marshmallow</td>
-    {% include progress-cell.html rowspan=1 percentage=97.7 %}
+    {% include progress-cell.html rowspan=1 percentage=98.2 %}
     <td rowspan="2">2015</td>
   </tr>
   <tr>
@@ -170,12 +170,12 @@ This is an overview of all Android versions and their corresponding identifiers 
     <td>Level 22 <span class="subversion">Android 5.1</span></td>
     <td><code>LOLLIPOP_MR1</code></td>
     <td rowspan="2">Lollipop</td>
-    {% include progress-cell.html rowspan=1 percentage=98.6 %}
+    {% include progress-cell.html rowspan=1 percentage=99.1 %}
   </tr>
   <tr>
     <td>Level 21 <span class="subversion">Android 5.0</span></td>
     <td><code>LOLLIPOP</code>, <code>L</code></td>
-    {% include progress-cell.html rowspan=2 percentage=99.1 %}
+    {% include progress-cell.html rowspan=2 percentage=99.4 %}
     <td rowspan="3">2014</td>
   </tr>
   <tr class="table-notes"><td colspan="3">
@@ -192,7 +192,7 @@ This is an overview of all Android versions and their corresponding identifiers 
     </td>
     <td><code>KITKAT_WATCH</code></td>
     <td rowspan="2">KitKat</td>
-    {% include progress-cell.html rowspan=3 percentage=99.4 %}
+    {% include progress-cell.html rowspan=3 percentage=99.7 %}
   </tr>
   <tr>
     <td>
@@ -211,18 +211,18 @@ This is an overview of all Android versions and their corresponding identifiers 
     <td>Level 18 <span class="subversion">Android 4.3</span></td>
     <td><code>JELLY_BEAN_MR2</code></td>
     <td rowspan="3">Jelly Bean</td>
-    {% include progress-cell.html rowspan=1 percentage=99.4 %}
+    {% include progress-cell.html rowspan=1 percentage=99.8 %}
   </tr>
   <tr>
     <td>Level 17 <span class="subversion">Android 4.2</span></td>
     <td><code>JELLY_BEAN_MR1</code></td>
-    {% include progress-cell.html rowspan=1 percentage=99.4 %}
+    {% include progress-cell.html rowspan=1 percentage=99.8 %}
     <td rowspan="3">2012</td>
   </tr>
   <tr>
     <td>Level 16 <span class="subversion">Android 4.1</span></td>
     <td><code>JELLY_BEAN</code></td>
-    {% include progress-cell.html rowspan=1 percentage=99.4 %}
+    {% include progress-cell.html rowspan=1 percentage=99.8 %}
   </tr>
 <tr class="table-notes"><td colspan="3">
     <ul>
@@ -364,7 +364,7 @@ This is an overview of all Android versions and their corresponding identifiers 
 <div class="footnotes">
   <ol>
     <li id="fn:1">
-      <p>Cumulative usage distribution figures were last updated on <b>November 14, 2023</b> using data from <a href="https://gs.statcounter.com/android-version-market-share/mobile-tablet/worldwide">Statcounter GlobalStats</a> and <a href="https://github.com/ebelinski/apilevels/blob/main/meta/android-usage-generator.swift">this script</a>. These figures may have changed significantly since the last update. You may update the figures yourself with a <a href="https://github.com/ebelinski/apilevels">pull request</a>. <a href="#fnref:1" class="reversefootnote">↩</a></p>
+      <p>Cumulative usage distribution figures were last updated on <b>December 4, 2023</b> using data from <a href="https://gs.statcounter.com/android-version-market-share/mobile-tablet/worldwide">Statcounter GlobalStats</a> and <a href="https://github.com/ebelinski/apilevels/blob/main/meta/android-usage-generator.swift">this script</a>. These figures may have changed significantly since the last update. You may update the figures yourself with a <a href="https://github.com/ebelinski/apilevels">pull request</a>. <a href="#fnref:1" class="reversefootnote">↩</a></p>
     </li>
     <li id="fn:2">
       <p>The codenames for Android 10 and above in the table are the internal codenames. Beginning with Android 10, Google dropped the usage of codenames publicly. <a href="#fnref:2" class="reversefootnote">↩</a></p>


### PR DESCRIPTION
NB these were generated from the Python script in #46, so the data for Android 13 includes the cumulative for Android 14.

TODO: if #46 is accepted, update it to automatically re-write the date line and also update the link in that line.