### PR TITLE
Add note about minSdk 21 (AndroidX)

### DIFF
--- a/index.md
+++ b/index.md
@@ -193,6 +193,7 @@ This is an overview of all Android versions and their corresponding identifiers 
   </tr>
   <tr class="table-notes"><td colspan="3">
     <ul>
+      <li><a href="https://developer.android.com/jetpack">Jetpack</a>/<a href="https://developer.android.com/jetpack/androidx">AndroidX</a> libraries <a href="https://developer.android.com/jetpack/androidx/versions#version-table">require</a> a <code>minSdk</code> of 21 or higher since April 2024.</li>
       <li><a href="https://developer.android.com/jetpack/compose">Jetpack Compose</a> requires a <code>minSdk</code> of 21 or higher.</li>
       <li>Google Play services v23.30.99+ (August 2023) <a href="https://android-developers.googleblog.com/2023/07/google-play-services-discontinuing-updates-for-kitkat.html">drops support</a> for API levels below 21.</li>
     </ul>


### PR DESCRIPTION
Couldn't find a proper (blog) announcement but there is a big warning on the website:

![image](https://github.com/ebelinski/apilevels/assets/2906988/45444187-d133-483f-b51c-52234244cdf4)

\+ PRs started failing to compile: https://github.com/TWiStErRob/android-lint-examples/pull/67

```
Execution failed for task '...:processDebugMainManifest'.
> Manifest merger failed : uses-sdk:minSdkVersion 14 cannot be smaller than version 21 declared in library [androidx.appcompat:appcompat-resources:1.7.0] /home/runner/.gradle/caches/8.8-rc-2/transforms/bd5f4f58eb143a6fc57ebc3ec976ba60/transformed/appcompat-resources-1.7.0/AndroidManifest.xml as the library might be using APIs not available in 14
  	Suggestion: use a compatible library with a minSdk of at most 14,
  		or increase this project's minSdk version to at least 21,
  		or use tools:overrideLibrary="androidx.appcompat.resources" to force usage (may lead to runtime failures)
```