### PR TITLE
Adds Android 15 release year

### DIFF
--- a/index.md
+++ b/index.md
@@ -38,7 +38,7 @@ This is an overview of all Android versions and their corresponding identifiers 
       <sup id="fnref:2"><a href="#fn:2" class="footnote">2</a></sup>
     </td>
     <td>—</td>
-    <td><i>TBD</i></td>
+    <td><i>2024</i></td>
   </tr>
   <tr>
     <td rowspan="2">
@@ -388,7 +388,7 @@ This is an overview of all Android versions and their corresponding identifiers 
       <p>Android 4.4W is the first Android release for Android Wear. <a href="#fnref:3" class="reversefootnote">↩</a></p>
     </li>
     <li id="fn:4">
-      <p>The years represent the year of first stable release of each version. The release dates are from <a href="https://developer.android.com/reference/android/os/Build.VERSION_CODES#constants_1"><code>android.os.Build.VERSION_CODES</code></a> including later versions' years from the <a href="https://blog.google/products/android/">Official Android blog</a> (<a href="https://blog.google/products/android/android-12/">12</a>, <a href="https://blog.google/products/android/12l-larger-screens/">12L</a>, <a href="https://blog.google/products/android/android-13/">13</a>, <a href="https://blog.google/products/android/android-14/">14</a>) <a href="#fnref:4" class="reversefootnote">↩</a></p>
+      <p>The years represent the year of first stable release of each version. The release dates are from <a href="https://developer.android.com/reference/android/os/Build.VERSION_CODES#constants_1"><code>android.os.Build.VERSION_CODES</code></a> including later versions' years from the <a href="https://blog.google/products/android/">Official Android blog</a> (<a href="https://blog.google/products/android/android-12/">12</a>, <a href="https://blog.google/products/android/12l-larger-screens/">12L</a>, <a href="https://blog.google/products/android/android-13/">13</a>, <a href="https://blog.google/products/android/android-14/">14</a>, <a href="https://blog.google/products/android/android-15/">15</a>) <a href="#fnref:4" class="reversefootnote">↩</a></p>
     </li>
   </ol>
 </div>


### PR DESCRIPTION
Android 15 is stable and released for Pixel devices as of 2024-10-15 <sup>[\[1\]](https://blog.google/products/android/android-15/) [\[2\]](https://developer.android.com/topic/generic-system-image/releases#15-stable).</sup>

This adds 2024 as the Android 15 release year and appends the corresponding 15th October 2024 blog URL to the footnotes.