### PR TITLE
"BETA" tag removed from Android 16

### DIFF
--- a/index.md
+++ b/index.md
@@ -29,7 +29,7 @@ This is an overview of all Android versions and their corresponding identifiers 
   </tr>
   <tr>
     <td>
-      <b><a href="https://developer.android.com/about/versions/16">Android 16</a> <sup class="beta">BETA</sup></b>
+      <a href="https://developer.android.com/about/versions/16">Android 16</a></b>
     </td>
     <td>Level 36</td>
     <td><code>BAKLAVA</code></td>


### PR DESCRIPTION
On June 10, 2025, the stable version of Android 16 was released, both in AOSP and for the Google Pixel devices, so the Beta label is no longer necessary.

PS.: I left a typo by accident, sorry