### PR TITLE
Add release date for API 36

### DIFF
--- a/index.md
+++ b/index.md
@@ -38,7 +38,7 @@ This is an overview of all Android versions and their corresponding identifiers 
       <sup id="fnref:2"><a href="#fn:2" class="footnote">2</a></sup>
     </td>
     {% include progress-cell.html rowspan=1 percentage=0 %}
-    <td><i>TBD</i></td>
+    <td>2025</td>
   </tr>
   <tr>
     <td>


### PR DESCRIPTION
API 36 (Android 16) is now out, [source](https://www.engadget.com/mobile/android-16-is-out-complete-with-new-features-for-pixel-phones-including-live-notification-updates-170006935.html).