### PR TITLE
Fix cell height of API 23 usage

### DIFF
--- a/index.md
+++ b/index.md
@@ -179,7 +179,7 @@ This is an overview of all Android versions and their corresponding identifiers 
     <td>Level 23</td>
     <td><code>M</code></td>
     <td>Marshmallow</td>
-    {% include progress-cell.html rowspan=1 percentage=97.5 %}
+    {% include progress-cell.html rowspan=2 percentage=97.5 %}
     <td rowspan="3">2015</td>
   </tr>
   <tr class="table-notes"><td colspan="3">


### PR DESCRIPTION
Follow-up on #74
cc @emartynov

Current live version:
<img width="1105" height="268" alt="image" src="https://github.com/user-attachments/assets/7d18b65e-1103-4bed-b241-ca405e110493" />
