### PR TITLE
Make preview in GitHub work structurally.

### DIFF
--- a/_includes/progress-cell.html
+++ b/_includes/progress-cell.html
@@ -1,17 +1,16 @@
 <style>
-  #cell{{ include.percentage | remove: "." }} {
+  td:has(#cell{{ include.percentage | remove: "." }}) {
     width: 100%
     height: 100%;
     background: linear-gradient(to right, #60ECAD {{ include.percentage }}%, white {{ include.percentage }}%);
   }
 
   @media (prefers-color-scheme: dark) {
-    #cell{{ include.percentage | remove: "." }} {
+    td:has(#cell{{ include.percentage | remove: "." }}) {
       background: linear-gradient(to right, #006236 {{ include.percentage }}%, rgba(0, 0, 0, 0) {{ include.percentage }}%);
     }
   }
 </style>
 
-<td rowspan="{{ include.rowspan }}" id="cell{{ include.percentage | remove: "." }}">
-  {{ include.percentage }}%
-</td>
+<a id="cell{{ include.percentage | remove: "." }}" />
+{{ include.percentage }}%

--- a/_includes/progress-cell.html
+++ b/_includes/progress-cell.html
@@ -1,7 +1,5 @@
 <style>
   td:has(#cell{{ include.percentage | remove: "." }}) {
-    width: 100%
-    height: 100%;
     background: linear-gradient(to right, #60ECAD {{ include.percentage }}%, white {{ include.percentage }}%);
   }
 

--- a/index.md
+++ b/index.md
@@ -179,7 +179,7 @@ This is an overview of all Android versions and their corresponding identifiers 
     <td>Level 23</td>
     <td><code>M</code></td>
     <td>Marshmallow</td>
-    {% include progress-cell.html rowspan=1 percentage=97.5 %}
+    {% include progress-cell.html rowspan=2 percentage=97.5 %}
     <td rowspan="3">2015</td>
   </tr>
   <tr class="table-notes"><td colspan="3">

--- a/index.md
+++ b/index.md
@@ -37,7 +37,7 @@ This is an overview of all Android versions and their corresponding identifiers 
       Baklava
       <sup id="fnref:2"><a href="#fn:2" class="footnote">2</a></sup>
     </td>
-    {% include progress-cell.html rowspan=1 percentage=4.6 %}
+    <td rowspan="1">{% include progress-cell.html percentage=4.6 %}</td>
     <td>2025</td>
   </tr>
   <tr>
@@ -50,7 +50,7 @@ This is an overview of all Android versions and their corresponding identifiers 
       Vanilla Ice Cream
       <sup id="fnref:2"><a href="#fn:2" class="footnote">2</a></sup>
     </td>
-    {% include progress-cell.html rowspan=2 percentage=34.4 %}
+    <td rowspan="2">{% include progress-cell.html percentage=34.4 %}</td>
     <td rowspan="2">2024</td>
   </tr>
   <tr class="table-notes">
@@ -70,7 +70,7 @@ This is an overview of all Android versions and their corresponding identifiers 
       Upside Down Cake
       <sup id="fnref:2"><a href="#fn:2" class="footnote">2</a></sup>
     </td>
-    {% include progress-cell.html rowspan=1 percentage=49.4 %}
+    <td rowspan="1">{% include progress-cell.html percentage=49.4 %}</td>
     <td rowspan="1">2023</td>
   </tr>
   <tr>
@@ -83,7 +83,7 @@ This is an overview of all Android versions and their corresponding identifiers 
       Tiramisu
       <sup id="fnref:2"><a href="#fn:2" class="footnote">2</a></sup>
     </td>
-    {% include progress-cell.html rowspan=1 percentage=64.4 %}
+    <td rowspan="1">{% include progress-cell.html percentage=64.4 %}</td>
     <td rowspan="2">2022</td>
   </tr>
   <tr>
@@ -99,7 +99,7 @@ This is an overview of all Android versions and their corresponding identifiers 
       Snow Cone
       <sup id="fnref:2"><a href="#fn:2" class="footnote">2</a></sup>
     </td>
-    {% include progress-cell.html rowspan=2 percentage=75.3 %}
+    <td rowspan="2">{% include progress-cell.html percentage=75.3 %}</td>
   </tr>
   <tr>
     <td>Level 31 <span class="subversion">Android 12</span></td>
@@ -116,7 +116,7 @@ This is an overview of all Android versions and their corresponding identifiers 
       Red Velvet Cake
       <sup id="fnref:2"><a href="#fn:2" class="footnote">2</a></sup>
     </td>
-    {% include progress-cell.html rowspan=1 percentage=84.4 %}
+    <td rowspan="1">{% include progress-cell.html percentage=84.4 %}</td>
     <td>2020</td>
   </tr>
   <tr>
@@ -129,7 +129,7 @@ This is an overview of all Android versions and their corresponding identifiers 
       Quince Tart
       <sup id="fnref:2"><a href="#fn:2" class="footnote">2</a></sup>
     </td>
-    {% include progress-cell.html rowspan=1 percentage=89.1 %}
+    <td rowspan="1">{% include progress-cell.html percentage=89.1 %}</td>
     <td>2019</td>
   </tr>
   <tr>
@@ -139,7 +139,7 @@ This is an overview of all Android versions and their corresponding identifiers 
     <td>Level 28</td>
     <td><code>P</code></td>
     <td>Pie</td>
-    {% include progress-cell.html rowspan=1 percentage=91.8 %}
+    <td rowspan="1">{% include progress-cell.html percentage=91.8 %}</td>
     <td>2018</td>
   </tr>
   <tr>
@@ -149,13 +149,13 @@ This is an overview of all Android versions and their corresponding identifiers 
     <td>Level 27 <span class="subversion">Android 8.1</span></td>
     <td><code>O_MR1</code></td>
     <td rowspan="2">Oreo</td>
-    {% include progress-cell.html rowspan=1 percentage=93.4 %}
+    <td rowspan="1">{% include progress-cell.html percentage=93.4 %}</td>
     <td rowspan="2">2017</td>
   </tr>
   <tr>
     <td>Level 26 <span class="subversion">Android 8.0</span></td>
     <td><code>O</code></td>
-    {% include progress-cell.html rowspan=1 percentage=94.8 %}
+    <td rowspan="1">{% include progress-cell.html percentage=94.8 %}</td>
   </tr>
   <tr>
     <td rowspan="2">
@@ -164,13 +164,13 @@ This is an overview of all Android versions and their corresponding identifiers 
     <td>Level 25 <span class="subversion">Android 7.1</span></td>
     <td><code>N_MR1</code></td>
     <td rowspan="2">Nougat</td>
-    {% include progress-cell.html rowspan=1 percentage=95.1 %}
+    <td rowspan="1">{% include progress-cell.html percentage=95.1 %}</td>
     <td rowspan="2">2016</td>
   </tr>
   <tr>
     <td>Level 24 <span class="subversion">Android 7.0</span></td>
     <td><code>N</code></td>
-    {% include progress-cell.html rowspan=1 percentage=95.7 %}
+    <td rowspan="1">{% include progress-cell.html percentage=95.7 %}</td>
   </tr>
   <tr>
     <td rowspan="2">
@@ -179,7 +179,7 @@ This is an overview of all Android versions and their corresponding identifiers 
     <td>Level 23</td>
     <td><code>M</code></td>
     <td>Marshmallow</td>
-    {% include progress-cell.html rowspan=2 percentage=97.5 %}
+    <td rowspan="2">{% include progress-cell.html percentage=97.5 %}</td>
     <td rowspan="3">2015</td>
   </tr>
   <tr class="table-notes"><td colspan="3">
@@ -194,12 +194,12 @@ This is an overview of all Android versions and their corresponding identifiers 
     <td>Level 22 <span class="subversion">Android 5.1</span></td>
     <td><code>LOLLIPOP_MR1</code></td>
     <td rowspan="2">Lollipop</td>
-    {% include progress-cell.html rowspan=1 percentage=97.8 %}
+    <td rowspan="1">{% include progress-cell.html percentage=97.8 %}</td>
   </tr>
   <tr>
     <td>Level 21 <span class="subversion">Android 5.0</span></td>
     <td><code>LOLLIPOP</code>, <code>L</code></td>
-    {% include progress-cell.html rowspan=2 percentage=99.8 %}
+    <td rowspan="2">{% include progress-cell.html percentage=99.8 %}</td>
     <td rowspan="3">2014</td>
   </tr>
   <tr class="table-notes"><td colspan="3">
@@ -217,7 +217,7 @@ This is an overview of all Android versions and their corresponding identifiers 
     </td>
     <td><code>KITKAT_WATCH</code></td>
     <td rowspan="2">KitKat</td>
-    {% include progress-cell.html rowspan=3 percentage=99.8 %}
+    <td rowspan="3">{% include progress-cell.html percentage=99.8 %}</td>
   </tr>
   <tr>
     <td>
@@ -237,18 +237,18 @@ This is an overview of all Android versions and their corresponding identifiers 
     <td>Level 18 <span class="subversion">Android 4.3</span></td>
     <td><code>JELLY_BEAN_MR2</code></td>
     <td rowspan="3">Jelly Bean</td>
-    {% include progress-cell.html rowspan=1 percentage=99.9 %}
+    <td rowspan="1">{% include progress-cell.html percentage=99.9 %}</td>
   </tr>
   <tr>
     <td>Level 17 <span class="subversion">Android 4.2</span></td>
     <td><code>JELLY_BEAN_MR1</code></td>
-    {% include progress-cell.html rowspan=1 percentage=99.9 %}
+    <td rowspan="1">{% include progress-cell.html percentage=99.9 %}</td>
     <td rowspan="3">2012</td>
   </tr>
   <tr>
     <td>Level 16 <span class="subversion">Android 4.1</span></td>
     <td><code>JELLY_BEAN</code></td>
-    {% include progress-cell.html rowspan=2 percentage=99.9 %}
+    <td rowspan="2">{% include progress-cell.html percentage=99.9 %}</td>
   </tr>
   <tr class="table-notes"><td colspan="3">
     <ul>
@@ -259,7 +259,7 @@ This is an overview of all Android versions and their corresponding identifiers 
     <td>Level 15 <span class="subversion">Android 4.0.3 – 4.0.4</span></td>
     <td><code>ICE_CREAM_SANDWICH_MR1</code></td>
     <td rowspan="2">Ice Cream Sandwich</td>
-    {% include progress-cell.html rowspan=3 percentage=99.9 %}
+    <td rowspan="3">{% include progress-cell.html percentage=99.9 %}</td>
     <td rowspan="7">2011</td>
   </tr>
   <tr>


### PR DESCRIPTION
This makes it easier to diff changes and miss less rowspan changes. (e.g. #76, which is included in this PR too to reduce conflicts.)

| Before | After |
| - | - |
| <img width="893" height="1639" alt="image" src="https://github.com/user-attachments/assets/a65ab0a2-a8bf-4d54-81b1-8bb3e4c32e35" /> | <img width="831" height="1911" alt="image" src="https://github.com/user-attachments/assets/c26a52a0-330b-4ae1-a915-c59c52a75056" /> |
